### PR TITLE
Upgrade Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "description": "Hosting Website for A Host 4 All",
   "dependencies": {
     "docpad": "~6.79.0",
-    "docpad-plugin-cleanurls": "~2.10.0",
-    "docpad-plugin-eco": "~2.2.1",
+    "docpad-plugin-cleanurls": "~2.11.0",
+    "docpad-plugin-eco": "~2.3.0",
     "docpad-plugin-ghpages": "~2.6.1",
     "docpad-plugin-highlightjs": "~2.5.0",
-    "docpad-plugin-jshint": "~2.2.1",
     "docpad-plugin-less": "~2.5.1",
     "docpad-plugin-livereload": "~2.9.0",
     "docpad-plugin-marked": "~2.4.0",


### PR DESCRIPTION
Cleanurl 2.10.0 to 2.11.0
eco 2.2.1 to 2.3.0
ghpages 2.6.1 to 2.7.0
removing  "docpad-plugin-jshint": "~2.2.1",